### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/Demo/align/detect_face.py
+++ b/Demo/align/detect_face.py
@@ -775,7 +775,7 @@ def nms(boxes, threshold, method):
         w = np.maximum(0.0, xx2-xx1+1)
         h = np.maximum(0.0, yy2-yy1+1)
         inter = w * h
-        if method is 'Min':
+        if method == 'Min':
             o = inter / np.minimum(area[i], area[idx])
         else:
             o = inter / (area[i] + area[idx] - inter)


### PR DESCRIPTION
Use ==/!= to compare str, bytes, and int literals because identity is not the same thing as equality in Python. This instance will raise a SyntaxWarning on Python >= 3.8 so it is best to fix it now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

[flake8](http://flake8.pycqa.org) testing of https://github.com/papermsucode/advhat on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./Demo/align/detect_face.py:778:12: F632 use ==/!= to compare str, bytes, and int literals
        if method is 'Min':
           ^
1     F632 use ==/!= to compare str, bytes, and int literals
1
```